### PR TITLE
Fix the build and correct the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ To build the pointpillars inference, **TensorRT** with PillarScatter layer and *
 $ cd test
 $ mkdir build
 $ cd build
+$ cmake .
 $ make -j$(nproc)
 ```
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,12 @@
 cmake_minimum_required(VERSION 2.8.7)
 set(PROJECT_NAME demo)
 find_package(CUDA REQUIRED)
+include_directories(
+    ${CUDA_INCLUDE_DIRS}
+    ${TENSORRT_INCLUDE_DIRS}
+    ../include/
+    ../include/plugin/
+)
 
 set(CMAKE_C_COMPILER /usr/bin/aarch64-linux-gnu-gcc)
 set(CMAKE_CXX_COMPILER /usr/bin/aarch64-linux-gnu-g++)
@@ -48,13 +54,6 @@ set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}
 
 set(TENSORRT_INCLUDE_DIRS /usr/include/aarch64-linux-gnu/)
 set(TENSORRT_LIBRARY_DIRS /usr/lib/aarch64-linux-gnu/)
-
-include_directories(
-    ${CUDA_INCLUDE_DIRS}
-    ${TENSORRT_INCLUDE_DIRS}
-    ../include/
-    ../include/plugin/
-)
 
 link_directories(
 	${TENSORRT_LIBRARY_DIRS}


### PR DESCRIPTION
# Summary

The test build seems broken for me, complaining:

```
CUDA-PointPillars/test/main.cpp:22:10: fatal error: cuda_runtime.h: No such file or directory
```

I think this is due to the include directories shall be moved right after `find_package(CUDA REQUIRED)`. Besides the document seems missing the cmake part.

I have tested this locally on a Xavier and after the fix, it works fine for me.

