### PR TITLE
fix onnx exporter bug

### DIFF
--- a/tool/exporter.py
+++ b/tool/exporter.py
@@ -121,7 +121,7 @@ def main():
       dummy_input['voxels'] = dummy_voxels
       dummy_input['voxel_num_points'] = dummy_voxel_num
       dummy_input['voxel_coords'] = dummy_voxel_idxs
-      dummy_input['batch_size'] = 1
+      dummy_input['batch_size'] = torch.tensor(1)
 
       torch.onnx.export(model,       # model being run
           dummy_input,               # model input (or a tuple for multiple inputs)


### PR DESCRIPTION
This PR is related to https://github.com/NVIDIA-AI-IOT/CUDA-PointPillars/issues/50,
This commit fix the dummy_input['batch_size'] is int not  supported as JIT inputs/outputs. 