### PR TITLE
fix the bug of postprocess

### DIFF
--- a/src/postprocess_kernels.cu
+++ b/src/postprocess_kernels.cu
@@ -135,6 +135,8 @@ cudaError_t postprocess_launch(const float *cls_input,
   dim3 threads (num_anchors);
   dim3 blocks (bev_size);
 
+  bndbox_output[0]=0;
+  
   postprocess_kernal<<<blocks, threads, 0, stream>>>
                 (cls_input,
                  box_input,


### PR DESCRIPTION
Sometimes there is no object in my pointcloud,The following codes in postprocess_kernels.cu:
if (dev_cls[1] >= score_thresh)
  {
    int box_offset = loc_index * num_anchors * num_box_values + ith_anchor * num_box_values;
    int dir_cls_offset = loc_index * num_anchors * 2 + ith_anchor * 2;
    float *anchor_ptr = anchors + ith_anchor * 4;
    float z_offset = anchor_ptr[2] / 2 + anchor_bottom_heights[ith_anchor / 2];
    float anchor[7] = {x_offset, y_offset, z_offset, anchor_ptr[0], anchor_ptr[1], anchor_ptr[2], anchor_ptr[3]};
    float *box_encodings = box_input + box_offset;
..............
When the scores of all targets are less than the threshold,the code will not run in this branch,the value of bndbox_output will not be updated, Instead, the result of the previous frame is used.
So,Before entering the kernel, I use "bndbox_output[0]=0;" to prevent unnecessary output in pointpillar.cpp.
