### PR TITLE
Support latest version of OpenPCDet v0.6.0 (8caccce) & Support PyTorch 2.x & Fix several bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ nvidia-docker run --rm -ti -v /home/$USER/:/home/$USER/ --net=host --rm pointpil
 For model exporting, please run the following command to clone pcdet repo and install custom CUDA extensions:
 ```
 git clone https://github.com/open-mmlab/OpenPCDet.git
-cd OpenPCDet && git checkout 846cf3e && python3 setup.py develop
+cd OpenPCDet && git checkout 8caccce && python3 setup.py develop
 ```
 Download [PTM](https://drive.google.com/file/d/1wMxWTpU1qUoY3DsCH31WJmvJxcjFXKlm/view) to ckpts/, then use below command to export ONNX model:
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,5 +7,5 @@ RUN apt-get update && apt install -y tzdata
 RUN apt-get install -y python3.8 python3-pip git libgl1-mesa-glx libglib2.0-0
 
 RUN pip install torch==1.10.0+cu113 torchvision==0.11.1+cu113 torchaudio==0.10.0+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
-RUN pip install pyyaml scikit-image onnx onnx-simplifier spconv==2.3.6 pillow==10.0.0 numba==0.58.0 opencv-python
+RUN pip install pyyaml scikit-image onnx==1.15.0 onnx-simplifier spconv==2.3.6 pillow==10.0.0 numba==0.58.0 opencv-python
 RUN pip install onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com


### PR DESCRIPTION
### Updates
1. Support latest version of [OpenPCDet v0.6.0 (8cacccec11db6f59bf6934600c9a175dae254806)](https://github.com/open-mmlab/OpenPCDet/tree/8cacccec11db6f59bf6934600c9a175dae254806), which supports PyTorch 2.x now.
2. Fix bugs:
- `TypeError: forward() missing 1 required positional argument: 'batch_dict'`
-  #72
-  #97
-  #124 
- `name: xxxxxx OpType: ScatterND is not output of any previous nodes.`
- #121 
3. Modified related files such as readme.md and dockerfile
4. Tested on:
- Ubuntu 20.0.4 LTS
- CUDA 12.8
- TensorRT 8.6.1.6
- torch==2.2.0+cu121
- onnx==1.15.0
- onnxsim==0.4.36
- pcdet==0.6.0+8caccce

